### PR TITLE
Fix example JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The clustermap chart expects data in the following format:
               "name": "Gene 1",
               "start": 2300,
               "end": 5000,
-              "strand": 1,
+              "strand": 1
             }
           ]
         }
@@ -45,7 +45,7 @@ The clustermap chart expects data in the following format:
       },
       "identity": 0.5
     }
-  ],
+  ]
 }
 ```
 


### PR DESCRIPTION
clustermap doesn't run with provided example data and doesn't pass online json validators
Removing trailing commas results in json validation passing and working clustermap

Info on trailing commas in JSON
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#trailing_commas_in_json